### PR TITLE
navigate between map/other view

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'src/pinpoint_map.dart';
+import 'src/tabs_navigation.dart';
 
 void main() => runApp(MyApp());
 
@@ -8,7 +9,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Welcome to our app!',
-      home: PinPointMap(),
+      home:  TabBarNav(),
     );
   }
 }

--- a/lib/src/tabs_navigation.dart
+++ b/lib/src/tabs_navigation.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'pinpoint_map.dart';
+
+class TabBarNav extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text("PinPoint"),
+          bottom: TabBar(
+            tabs: [
+              Tab(
+                icon: Icon(Icons.pin_drop),
+              ),
+              Tab(
+                icon: Icon(Icons.map),
+              ),
+            ],
+          ),
+        ),
+        body: TabBarView(children: [
+          Center(
+            child: Text("Here goes a list of my pinpoints"),
+          ),
+          PinPointMap(),
+        ]),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Created a tab navigation bar for switching between map and the list of pinpoints views. I created it by following the tutorial on flutter.dev site but we can ofcourse change it later on. This is mainly so that we can continue working on both views at the same time